### PR TITLE
Add Dependabot and Gradle Wrapper update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,24 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # Covers gradle/libs.versions.toml, build.gradle, settings.gradle and the
+  # :mobile subproject, which Dependabot discovers via settings.gradle.
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "gradle"
+    groups:
+      # Batch low-risk bumps; majors (e.g. AGP) still get their own PR.
+      gradle-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,30 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-gradle-wrapper:
+    name: Update Gradle Wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v6.0.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2.1.0
+        with:
+          labels: dependencies, gradle


### PR DESCRIPTION
## Summary
This PR adds automated dependency management and Gradle Wrapper updates to the project by introducing Dependabot configuration and a dedicated GitHub Actions workflow.

## Key Changes
- **Dependabot Configuration** (`.github/dependabot.yml`):
  - Enables automated updates for GitHub Actions dependencies on a weekly schedule
  - Enables automated updates for Gradle dependencies on a weekly schedule with a limit of 5 open PRs
  - Groups minor and patch version updates together to reduce PR noise
  - Major version updates are kept separate for individual review
  - Applies appropriate labels (`dependencies`, `github-actions`, `gradle`) and commit prefixes (`ci`, `deps`) for organization

- **Gradle Wrapper Update Workflow** (`.github/workflows/update-gradle-wrapper.yml`):
  - Adds a dedicated workflow to automatically update the Gradle Wrapper
  - Runs weekly on Mondays at 06:00 UTC with manual trigger support
  - Uses JDK 17 (Temurin distribution) for the update process
  - Creates pull requests with appropriate dependency labels

## Implementation Details
- Dependabot is configured to batch low-risk updates (minor/patch versions) while keeping major version bumps separate for careful review
- The Gradle Wrapper workflow is separate from Dependabot to provide more control over wrapper-specific updates
- Both automations use consistent labeling and commit message prefixes for easy filtering and organization

https://claude.ai/code/session_01BhsLz2kuv6pppo6sqLyyM5